### PR TITLE
Fix skiptokens with special characters.

### DIFF
--- a/src/sap/odata/util/lib/decorator/processing/postprocessing/skipTokenPostProcessor.xsjslib
+++ b/src/sap/odata/util/lib/decorator/processing/postprocessing/skipTokenPostProcessor.xsjslib
@@ -93,9 +93,10 @@ SkipTokenPostProcessor.prototype.getNextSkipToken = function(lastObject) {
 		Date.latestSafeTimestamp().getTime());
 	
 	this.getMetadata().keys.forEach(function(key) {
-		token += '-' + encodeURIComponent('' + lastObject[key.name]);
+		// URI encode and also replace '~' with '~-' in the key values to avoid conflicts with
+		// the separator ~~. It will be converted back in skipTokenProcessor.getCurrentSkipToken()
+		token += '~~' + encodeURIComponent('' + lastObject[key.name]).replace(/~/g,'~-');
 	});
 	
 	return token;
 };
-

--- a/src/sap/odata/util/lib/decorator/processing/processor.xsjslib
+++ b/src/sap/odata/util/lib/decorator/processing/processor.xsjslib
@@ -72,7 +72,12 @@ Processor.prototype.getMetadata = function() {
  */
 Processor.prototype.querify = function(parameters) {
 	return parameters.map(function(entry) {
-		return entry.key + '=' + escape(entry.value);
+		var value = entry.value;
+		if(entry.key !== '$skiptoken') {
+			// $skiptoken has already been escaped
+			value = escape(value);
+		}
+		return entry.key + '=' + value;
 	}).join('&');
 };
 

--- a/src/sap/odata/util/lib/decorator/processing/skipTokenProcessor.xsjslib
+++ b/src/sap/odata/util/lib/decorator/processing/skipTokenProcessor.xsjslib
@@ -10,7 +10,7 @@ function SkipTokenProcessor(request, metadataClient) {
 	
 	request && Object.defineProperties(this, {
 		'skipTokenSeparator': {
-			value: '-'
+			value: '~~'
 		},
 		'pageSize': {
 			value: parseInt(this.getConfiguredValue('skiptoken.pageSize'), 10)
@@ -39,7 +39,7 @@ SkipTokenProcessor.prototype.isActive = function() {
  * </code></pre> parameter or null, if there is none.
  *
  * A skip token is constructed as follows:
- * $skiptoken = timestamp-key[-key]*
+ * $skiptoken = timestamp~~key[~~key]*
  * 
  * The timestamp is the latest known safe point in time in terms of
  * snapshot isolation before the pagination started, and is carried over
@@ -61,7 +61,7 @@ SkipTokenProcessor.prototype.getCurrentSkipToken = function(request) {
 	return {
 		timestamp: parseInt(components[0], 10),
 		keys: components.splice(1, components.length - 1).map(function(encodedKey) {
-			return decodeURIComponent(encodedKey);
+			return decodeURIComponent(encodedKey).replace(/~-/g, '~');
 		}),
 		meta: this.getMetadata(),
 		raw: encodedToken


### PR DESCRIPTION
The skiptokens were being double excaped.
e.g. a space ' ' would become %2520 instead of %20

Also '-' was being used delimit the skip token.
This is a common character in GUIDs and was breaking
the parsing of the skiptoken.  Nestle worked around the
issue, but putting the fix in to protect against any
future problems.

The delimiter is now ~~
In addition, any ~s in the key values will be changed to
~- so you can even use ~~ in the keys without any issues.